### PR TITLE
Added getRepoData to parent class metrics

### DIFF
--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -6,7 +6,7 @@ dotenv.config();
 // Access the token value
 const githubToken = process.env.API_TOKEN;
 if (!githubToken) {
-    throw new Error('GITHUB_TOKEN is not defined in the .env file');
+    throw new Error('API_TOKEN is not defined in the .env file');
 }
 export let OCTOKIT: Octokit = new Octokit({ auth: githubToken, });
 

--- a/src/Metrics.ts
+++ b/src/Metrics.ts
@@ -19,9 +19,22 @@ export abstract class Metrics {
     public responseTime: number = 0;
     public octokit: Octokit = OCTOKIT;
     protected url: string;
+    protected owner: string;
+    protected repo: string;
 
     constructor(url: string) {
         this.url = url;
+        const { owner, repo } = this.getRepoData(this.url);
+        this.owner = owner;
+        this.repo = repo;
+        
+    }
+
+    private getRepoData(url: string): { owner: string; repo: string } {
+        const regex = /https:\/\/github\.com\/([^/]+)\/([^/]+)/;
+        const match = url.match(regex);
+        if (!match) throw new Error("Invalid GitHub URL");
+        return { owner: match[1], repo: match[2] };
     }
 
     abstract evaluate(): Promise<number>;

--- a/src/busFactor.ts
+++ b/src/busFactor.ts
@@ -33,8 +33,7 @@ export class BusFactor extends Metrics {
         }
 
         const startTime = performance.now();
-        const { owner, repo } = await this.getRepoData(this.url);
-        const commitData = await this.getCommitData(owner, repo);
+        const commitData = await this.getCommitData(this.owner, this.repo);
         this.busFactor = this.calculateBusFactor(commitData);
         const endTime = performance.now();
         const elapsedTime = Number(endTime - startTime) / 1e6; // Convert to milliseconds
@@ -43,21 +42,6 @@ export class BusFactor extends Metrics {
         return this.busFactor;
     }
 
-
-    /**
-     * Retrieves the owner and repository name from a given GitHub URL.
-     * 
-     * @param url - The GitHub URL to extract the owner and repository from.
-     * @returns A promise that resolves to an object containing the owner and repository name.
-     * @throws An error if the provided URL is invalid.
-     */
-    private async getRepoData(url: string): Promise<{ owner: string; repo: string }> {
-        const regex = /https:\/\/github\.com\/([^/]+)\/([^/]+)/;
-        const match = url.match(regex);
-        if (!match) throw new Error("Invalid GitHub URL");
-
-        return { owner: match[1], repo: match[2] };
-    }
 
     /**
      * Retrieves commit data for a given owner and repository.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,7 +73,8 @@ async function runTests() {
     console.log(`Bus Factor Test: ${apiRemaining[1] - apiRemaining[2]}`);
     console.log(`Correctness Test: ${apiRemaining[2] - apiRemaining[3]}`);
     console.log(`Ramp Up Test: ${apiRemaining[3] - apiRemaining[4]}`);
-    console.log(`Net Score Test: ${apiRemaining[4] - apiRemaining[5]}`);
+    console.log(`Maintainability Test: ${apiRemaining[4] - apiRemaining[5]}`);
+    console.log(`Net Score Test: ${apiRemaining[5] - apiRemaining[6]}`);
     console.log(`Total Rate Limit Used: ${usedRateLimit}`);
 
     // Display test results

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import { NetScore } from './netScore.js';
 import { BusFactorTest } from './busFactor.js';
 import { CorrectnessTest } from './correctness.js';
 import { LicenseTest } from './license.js';
-// import { MaintainabilityTest } from './maintainability';
+import { MaintainabilityTest } from './maintainability.js';
 import { RampUpTest } from './rampUp.js';
 import { NetScoreTest } from './netScore.js';
 import { exit } from 'process';
@@ -59,6 +59,8 @@ async function runTests() {
     results.push(await CorrectnessTest());
     apiRemaining.push((await OCTOKIT.rateLimit.get()).data.rate.remaining);
     results.push(await RampUpTest());
+    apiRemaining.push((await OCTOKIT.rateLimit.get()).data.rate.remaining);
+    results.push(await MaintainabilityTest());
     apiRemaining.push((await OCTOKIT.rateLimit.get()).data.rate.remaining);
     results.push(await NetScoreTest());
     apiRemaining.push((await OCTOKIT.rateLimit.get()).data.rate.remaining);

--- a/src/correctness.ts
+++ b/src/correctness.ts
@@ -77,13 +77,9 @@ export class Correctness extends Metrics {
      */
     private async fetchIssuesData(): Promise<{ openBugIssues: number; totalOpenIssues: number }> {
         try {
-            // Extract the owner and repo from the URL
-            const repoInfo = this.extractRepoInfo();
-            if (!repoInfo) {
-                throw new Error('Invalid repository URL');
-            }
-
-            const { owner, repo } = repoInfo;
+            const owner = this.owner;
+            const repo = this.repo;
+        
             const { data } = await this.octokit.issues.listForRepo({
                 owner,
                 repo,
@@ -101,22 +97,6 @@ export class Correctness extends Metrics {
             console.error('Error fetching issues data:', error);
             throw error;
         }
-    }
-
-    /**
-     * Extracts the owner and repository name from a GitHub URL.
-     * 
-     * @returns An object containing the owner and repo properties, or null if the URL is invalid.
-     */
-    private extractRepoInfo(): { owner: string; repo: string } | null {
-        // Regex to parse GitHub URL and extract owner and repository name
-        const regex = /https:\/\/github\.com\/([^\/]+)\/([^\/]+)/;
-        const match = this.url.match(regex);
-
-        if (match && match.length >= 3) {
-            return { owner: match[1], repo: match[2] };
-        }
-        return null;
     }
 }
 

--- a/src/maintainability.ts
+++ b/src/maintainability.ts
@@ -1,4 +1,5 @@
 import { Metrics } from "./Metrics.js";
+import { ASSERT_EQ, ASSERT_LT, ASSERT_NEAR } from './testUtils.js';
 
 
 export class Maintainability extends Metrics {
@@ -26,7 +27,7 @@ export class Maintainability extends Metrics {
                 owner: owner,
                 repo: repo,
                 state: "all",      // Fetch both open and closed issues
-                per_page: 25,     // Limit to 25 issues
+                per_page: 25,      // Limit to 25 issues
                 sort: "created",   // Sort by creation date
                 direction: "desc"  // Get the most recent issues first
             });
@@ -83,4 +84,34 @@ export class Maintainability extends Metrics {
         return this.maintainability;
 
     }
+}
+
+
+export async function MaintainabilityTest(): Promise<{ passed: number, failed: number }> {
+    let testsPassed = 0;
+    let testsFailed = 0;
+    let maintainabilityTests: Maintainability[] = [];
+
+    const url_to_expected_score = [
+        { url: "https://github.com/nullivex/nodist", expectedMaintainability: 0.01 },
+        { url: "https://github.com/cloudinary/cloudinary_npm", expectedMaintainability: 0.8 },
+        { url: "https://github.com/lodash/lodash", expectedMaintainability: 0.6 },
+    ];
+
+    for (const test of url_to_expected_score) {
+
+        let maintainability = new Maintainability(test.url);
+        let result = await maintainability.evaluate();
+
+        let threshold: number = 0.1
+        ASSERT_NEAR(result, test.expectedMaintainability, threshold, `Maintainability Test for ${test.url}`) ? testsPassed++ : testsFailed++;
+        
+        ASSERT_LT(maintainability.responseTime, 0.004, `Maintainability Response_Time Test for ${test.url}`) ? testsPassed++ : testsFailed++;
+
+        console.log(`Maintainability Response time: ${maintainability.responseTime.toFixed(6)}s\n`);
+
+        maintainabilityTests.push(maintainability);
+    }
+
+    return { passed: testsPassed, failed: testsFailed };
 }

--- a/src/maintainability.ts
+++ b/src/maintainability.ts
@@ -12,14 +12,6 @@ export class Maintainability extends Metrics {
         super(url);
     }
 
-    private async getRepoData(url: string): Promise<{ owner: string; repo: string }> {
-        const regex = /https:\/\/github\.com\/([^/]+)\/([^/]+)/;
-        const match = url.match(regex);
-        if (!match) throw new Error("Invalid GitHub URL");
-
-        return { owner: match[1], repo: match[2] };
-    }
-
     private async calculateMaintainability(owner: string, repo: string): Promise<number> {
         try {
             // Fetch the most recent 100 issues for the repository
@@ -74,8 +66,7 @@ export class Maintainability extends Metrics {
 
         const startTime = performance.now();
 
-        const { owner, repo } = await this.getRepoData(this.url);
-        this.maintainability = await this.calculateMaintainability(owner, repo);
+        this.maintainability = await this.calculateMaintainability(this.owner, this.repo);
 
         const endTime = performance.now();
         const elapsedTime = Number(endTime - startTime) / 1e6; // Convert to milliseconds

--- a/src/rampUp.ts
+++ b/src/rampUp.ts
@@ -22,18 +22,6 @@ export class RampUp extends Metrics {
         super(url);
     }
 
-    private extractOwnerRepo(url: string): { owner: string; repo: string } {
-        const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)/);
-        if (!match) {
-            throw new Error("Invalid GitHub URL");
-        }
-
-        return {
-            owner: match[1],
-            repo: match[2],
-        };
-    }
-
     async evaluate(): Promise<number> {
         const startTime = performance.now();
         this.rampUp = await this.printRepoStructure(this.url);
@@ -49,7 +37,9 @@ export class RampUp extends Metrics {
     */
     async printRepoStructure(url: string, path: string = ''): Promise<number> {
         try {
-            const { owner, repo } = this.extractOwnerRepo(url);
+            const owner = this.owner;
+            const repo = this.repo;
+            
             const response = await this.octokit.repos.getContent({
                 owner,
                 repo,


### PR DESCRIPTION
Almost every child function was running a separate version of the getRepoData function, this has been simplified by adding the function to the parent class Metrics, and adding the class variables owner and repo. All child classes have been adjusted.